### PR TITLE
Improve test harness with Diagnostic helpers

### DIFF
--- a/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
@@ -4,18 +4,20 @@ import com.abusalimov.mrcalc.compile.CompileErrorException
 import com.abusalimov.mrcalc.compile.Compiler
 import com.abusalimov.mrcalc.parse.Parser
 import com.abusalimov.mrcalc.parse.impl.antlr.ANTLRParserImpl
+import org.junit.Before
+import org.junit.Test
 
 /**
  * @author Eldar Abusalimov
  */
-class CompilerTest extends DiagnosticTestCase {
-    def diagnosticExceptionClass = CompileErrorException
+class CompilerTest {
+    def shouldDiagnose = DiagnosticAssert.&shouldDiagnose.curry CompileErrorException
 
     private Parser parser
     private Compiler compiler
 
+    @Before
     void setUp() {
-        super.setUp()
         parser = new ANTLRParserImpl()
         compiler = new Compiler()
     }
@@ -25,34 +27,40 @@ class CompilerTest extends DiagnosticTestCase {
         compiler.compile node
     }
 
-    void testCompilesExpressions() {
+    @Test
+    void "compiles simple math expressions"() {
         assert null != compile("0")
         assert null != compile("(1)")
         assert null != compile("(1+2)")
         assert null != compile("1+2-3*4/5^6")
     }
 
-    void testCompilesValidVarDefs() {
+    @Test
+    void "compiles valid variable definition statements"() {
         assert null != compile("var answer = 42")
         assert null != compile("var x = 0; var y = 1; var z = 3")
     }
 
-    void testCompilesValidVarRefs() {
+    @Test
+    void "compiles valid variable references"() {
         assert null != compile("var answer = 42; answer")
         assert null != compile("var x = 0; var y = 1; var z = 3; var foo = x+y+z")
     }
 
-    void "test error on duplicate variables"() {
+    @Test
+    void "reports error on duplicate variables"() {
         shouldDiagnose("already defined") { compile("var answer = 42; var answer = -1") }
     }
 
-    void "test error on undefined variables"() {
+    @Test
+    void "reports error on undefined variables"() {
         shouldDiagnose("undefined variable") { compile("unknown") }
         shouldDiagnose("undefined variable") { compile("var x = y + z") }
         shouldDiagnose("undefined variable") { compile("var foo = bar; var bar = foo") }
     }
 
-    void "test error on self-referencing variable"() {
+    @Test
+    void "reports error on self-referencing variable"() {
         shouldDiagnose("undefined variable") { compile("var r = r") }
     }
 }

--- a/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
@@ -29,22 +29,22 @@ class CompilerTest {
 
     @Test
     void "compiles simple math expressions"() {
-        assert null != compile("0")
-        assert null != compile("(1)")
-        assert null != compile("(1+2)")
-        assert null != compile("1+2-3*4/5^6")
+        assert compile("0")
+        assert compile("(1)")
+        assert compile("(1+2)")
+        assert compile("1+2-3*4/5^6")
     }
 
     @Test
     void "compiles valid variable definition statements"() {
-        assert null != compile("var answer = 42")
-        assert null != compile("var x = 0; var y = 1; var z = 3")
+        assert compile("var answer = 42")
+        assert compile("var x = 0; var y = 1; var z = 3")
     }
 
     @Test
     void "compiles valid variable references"() {
-        assert null != compile("var answer = 42; answer")
-        assert null != compile("var x = 0; var y = 1; var z = 3; var foo = x+y+z")
+        assert compile("var answer = 42; answer")
+        assert compile("var x = 0; var y = 1; var z = 3; var foo = x+y+z")
     }
 
     @Test

--- a/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/CompilerTest.groovy
@@ -8,7 +8,9 @@ import com.abusalimov.mrcalc.parse.impl.antlr.ANTLRParserImpl
 /**
  * @author Eldar Abusalimov
  */
-class CompilerTest extends GroovyTestCase {
+class CompilerTest extends DiagnosticTestCase {
+    def diagnosticExceptionClass = CompileErrorException
+
     private Parser parser
     private Compiler compiler
 
@@ -40,14 +42,17 @@ class CompilerTest extends GroovyTestCase {
         assert null != compile("var x = 0; var y = 1; var z = 3; var foo = x+y+z")
     }
 
-    void testThrowsErrorOnDuplicateVariable() {
-        shouldFail CompileErrorException, { compile("var answer = 42; var answer = -1") }
+    void "test error on duplicate variables"() {
+        shouldDiagnose("already defined") { compile("var answer = 42; var answer = -1") }
     }
 
-    void testThrowsErrorOnUndefinedVariable() {
-        shouldFail CompileErrorException, { compile("unknown") }
-        shouldFail CompileErrorException, { compile("var x = y + z") }
-        shouldFail CompileErrorException, { compile("var foo = bar; var bar = foo") }
-        shouldFail CompileErrorException, { compile("var r = r") }
+    void "test error on undefined variables"() {
+        shouldDiagnose("undefined variable") { compile("unknown") }
+        shouldDiagnose("undefined variable") { compile("var x = y + z") }
+        shouldDiagnose("undefined variable") { compile("var foo = bar; var bar = foo") }
+    }
+
+    void "test error on self-referencing variable"() {
+        shouldDiagnose("undefined variable") { compile("var r = r") }
     }
 }

--- a/src/test/groovy/com/abusalimov/mrcalc/DiagnosticAssert.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/DiagnosticAssert.groovy
@@ -1,0 +1,80 @@
+package com.abusalimov.mrcalc
+
+import com.abusalimov.mrcalc.diagnostic.Diagnostic
+import com.abusalimov.mrcalc.diagnostic.DiagnosticException
+import groovy.test.GroovyAssert
+
+import java.util.regex.Pattern
+
+/**
+ * Extends the standard set of assertions with methods for testing emitted Diagnostics.
+ *
+ * @author Eldar Abusalimov
+ */
+class DiagnosticAssert extends GroovyAssert {
+
+    /**
+     * Asserts that the given code closure throws a DiagnosticException of the specified type,
+     * and that at least one Diagnostic attached to the exception contains the given substring.
+     *
+     * @param clazz the specific exception class
+     * @param s the substring to search the diagnostic message for
+     * @param code the closure to evaluate
+     * @return the DiagnosticException thrown, if any, null otherwise
+     */
+    static DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = DiagnosticException,
+                                              String s, Closure code) {
+        shouldDiagnose(clazz, [s], code)
+    }
+
+    /**
+     * Asserts that the given code closure throws a DiagnosticException of the specified type,
+     * and that at least one Diagnostic attached to the exception matches the given pattern.
+     *
+     * @param clazz the specific exception class
+     * @param pat regex pattern to match the diagnostic against
+     * @param code the closure to evaluate
+     * @return the DiagnosticException thrown, if any, null otherwise
+     */
+    static DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = DiagnosticException,
+                                              Pattern pat, Closure code) {
+        shouldDiagnose(clazz, [pat], code)
+    }
+
+    /**
+     * Asserts that the given code closure throws a DiagnosticException of the specified type,
+     * and that Diagnostics attached to the exception match every pattern given.
+     *
+     * @param clazz the specific exception class
+     * @param patterns the list of string and/or regex pattern to test for
+     * @param code the closure to evaluate
+     * @return the DiagnosticException thrown, if any, null otherwise
+     */
+    static DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = DiagnosticException,
+                                              List<?> patterns, Closure code) {
+        def th = shouldFail(clazz, code)
+
+        if (th instanceof DiagnosticException) {
+            List<Diagnostic> diagnostics = ((DiagnosticException) th).diagnostics
+            patterns.each { matchAnyDiagnostic it, diagnostics }
+            return th
+        } else {
+            return null
+        }
+    }
+
+    private static void matchAnyDiagnostic(String s, List<Diagnostic> diagnostics) {
+        matchAnyDiagnostic Pattern.compile(s, Pattern.LITERAL | Pattern.CASE_INSENSITIVE), diagnostics
+    }
+
+    private static void matchAnyDiagnostic(Pattern pat, List<Diagnostic> diagnostics) {
+        if (!diagnostics.any { it.message =~ pat }) {
+            fail "No diagnostic matched '${pat}': ${diagnostics}"
+        }
+    }
+
+    private static void matchAnyDiagnostic(Object o, List<Diagnostic> diagnostics) {
+        // God bless multiple dispatch
+        throw new IllegalArgumentException("Expected String or Pattern")
+    }
+}

--- a/src/test/groovy/com/abusalimov/mrcalc/DiagnosticTestCase.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/DiagnosticTestCase.groovy
@@ -1,0 +1,39 @@
+package com.abusalimov.mrcalc
+
+import com.abusalimov.mrcalc.diagnostic.DiagnosticException
+
+import java.util.regex.Pattern
+
+/**
+ * A JUnit 3 TestCase base class with helper methods for testing Diagnostics.
+ *
+ * @see DiagnosticAssert
+ * @author Eldar Abusalimov
+ */
+abstract class DiagnosticTestCase extends GroovyTestCase {
+    def diagnosticExceptionClass = DiagnosticException
+
+    /**
+     * @see DiagnosticAssert#shouldDiagnose(java.lang.Class, java.lang.String, groovy.lang.Closure)
+     */
+    DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = getDiagnosticExceptionClass(),
+                                       String s, Closure code) {
+        DiagnosticAssert.shouldDiagnose(clazz, s, code)
+    }
+
+    /**
+     * @see DiagnosticAssert#shouldDiagnose(java.lang.Class, java.util.regex.Pattern, groovy.lang.Closure)
+     */
+    DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = getDiagnosticExceptionClass(),
+                                       Pattern pat, Closure code) {
+        DiagnosticAssert.shouldDiagnose(clazz, pat, code)
+    }
+
+    /**
+     * @see DiagnosticAssert#shouldDiagnose(java.lang.Class, java.util.List, groovy.lang.Closure)
+     */
+    DiagnosticException shouldDiagnose(Class<? extends DiagnosticException> clazz = getDiagnosticExceptionClass(),
+                                       List<?> patterns, Closure code) {
+        DiagnosticAssert.shouldDiagnose(clazz, patterns, code)
+    }
+}

--- a/src/test/groovy/com/abusalimov/mrcalc/InterpreterTest.groovy
+++ b/src/test/groovy/com/abusalimov/mrcalc/InterpreterTest.groovy
@@ -3,17 +3,21 @@ package com.abusalimov.mrcalc
 import com.abusalimov.mrcalc.compile.Compiler
 import com.abusalimov.mrcalc.parse.Parser
 import com.abusalimov.mrcalc.parse.impl.antlr.ANTLRParserImpl
+import org.junit.Before
+import org.junit.Test
+
+import static groovy.test.GroovyAssert.shouldFail
 
 /**
  * @author Eldar Abusalimov
  */
-class InterpreterTest extends GroovyTestCase {
+class InterpreterTest {
     private Parser parser
     private Compiler compiler
     private Interpreter interpreter
 
+    @Before
     void setUp() {
-        super.setUp()
         parser = new ANTLRParserImpl()
         compiler = new Compiler()
         interpreter = new Interpreter()
@@ -25,13 +29,15 @@ class InterpreterTest extends GroovyTestCase {
         interpreter.eval code
     }
 
-    void testEvalParsesParens() {
+    @Test
+    void "evaluates literals"() {
         assert 0L == eval("0")
         assert 1L == eval("(1)")
         assert 42L == eval(" ( 42 ) ")
     }
 
-    void testEvalCalculatesArithmetics() {
+    @Test
+    void "calculates simple math expressions"() {
         assert 1L == eval("0 + 1")
         assert 27L == eval("(1+2)^3")
         assert 42L == eval("1 + 5*8 + 1")
@@ -39,12 +45,14 @@ class InterpreterTest extends GroovyTestCase {
         shouldFail ArithmeticException, { eval "1/0" }
     }
 
-    void testEvalCalculatesWithVariables() {
+    @Test
+    void "can use variables"() {
         assert 1L == eval("var x = 1; x")
         assert 54L == eval("var six = 1 + 5; var nine = 8 + 1; six * nine")
     }
 
-    void testEvalCalculatesVariablesLazily() {
+    @Test
+    void "calculates variables lazily"() {
         assert 42L == eval("var fuuu = 1/0; 42")
     }
 }


### PR DESCRIPTION
Add a handy `shouldDiagnose()` assertion that inspects Diagnostics reported by code being tested. Also switch some tests to use JUnit4 and "verbatim" test method names.
